### PR TITLE
Remove option

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,30 +57,6 @@ Write tsdoc with `@nomnoml` annotation
 export class Hoge { }
 ```
 
-## Additional Options
-
-### Example: If you want to use `nomnoml@0.6.1`
-
-#### Set version by CLI
-
-Add `--nomnomlVersion 0.6.1` option.
-
-```bash
-typedoc --plugin typedoc-plugin-nomnoml --nomnomlVersion 0.6.1
-```
-
-#### Set version by `typedoc.json`
-
-Add `nomnomlVersion` config to `typedoc.json`.
-
-```json
-{
-  "mode": "file",
-  "out": "./docs",
-  "nomnomlVersion": "0.6.1"
-}
-```
-
 ### Help
 
 ```bash

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -3,9 +3,6 @@ import { Component, ConverterComponent } from 'typedoc/dist/lib/converter/compon
 import { Context } from 'typedoc/dist/lib/converter/context';
 import { Comment, CommentTag } from 'typedoc/dist/lib/models/comments';
 import { PageEvent } from 'typedoc/dist/lib/output/events';
-import { Option } from 'typedoc/dist/lib/utils';
-import { ParameterType } from 'typedoc/dist/lib/utils/options/declaration';
-
 /**
  * Nomnoml plugin component.
  */
@@ -17,7 +14,6 @@ export class NomnomlPlugin extends ConverterComponent {
    * 3. Close body tag.
    */
   private get customScriptsAndBodyClosinngTag(): string {
-    const nomnomlVersion = this.nomnomlVersion;
     const script = Array.from(this.graphMap.entries())
       .map(
         ([id, source]) =>
@@ -27,8 +23,8 @@ export class NomnomlPlugin extends ConverterComponent {
       )
       .join('\n');
     return `
-      <script src="https://cdnjs.cloudflare.com/ajax/libs/dagre/0.8.4/dagre.min.js"></script>
-      <script src="https://cdnjs.cloudflare.com/ajax/libs/nomnoml/${nomnomlVersion}/nomnoml.min.js"></script>
+      <script src="https://cdn.jsdelivr.net/npm/dagre/dist/dagre.min.js"></script>
+      <script src="https://cdn.jsdelivr.net/npm/nomnoml/dist/nomnoml.min.js"></script>
       <script>${script}</script>
       </body>
     `;
@@ -79,17 +75,6 @@ export class NomnomlPlugin extends ConverterComponent {
         .filter(this.isNomnomlCommentTag)
     );
   }
-
-  @Option({
-    name: 'nomnomlVersion',
-    defaultValue: '0.6.1',
-    help: 'Nomnoml Plugin: Version of nomnoml.',
-    type: ParameterType.String,
-  })
-  /**
-   * Version of nomnoml.
-   */
-  public nomnomlVersion: string;
 
   private graphMap = new Map<string, string>();
 

--- a/test/__snapshots__/plugin.test.ts.snap
+++ b/test/__snapshots__/plugin.test.ts.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NomnomlPlugin convert PageContents returns script tag for nomnoml.js, initialize nomnoml script, and body closing tag 1`] = `
+"
+      <script src=\\"https://cdn.jsdelivr.net/npm/dagre/dist/dagre.min.js\\"></script>
+      <script src=\\"https://cdn.jsdelivr.net/npm/nomnoml/dist/nomnoml.min.js\\"></script>
+      <script></script>
+      </body>
+    "
+`;

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -20,34 +20,9 @@ describe('NomnomlPlugin', () => {
     const input = '</body>';
     const result = plugin.convertPageContents(input);
     expect(result).toMatch('</body>');
-    expect(result).toMatch(
-      /<script src=\"https:\/\/cdnjs.cloudflare.com\/ajax\/libs\/dagre\/[\d|.]+\/dagre.min.js\"><\/script>/,
-    );
-    expect(result).toMatch(
-      /<script src=\"https:\/\/cdnjs.cloudflare.com\/ajax\/libs\/nomnoml\/[\d|.]+\/nomnoml.min.js\"><\/script>/,
-    );
-  });
-
-  // tslint:disable-next-line: quotemark
-  it("can be change nomnoml.js version when set 'nomnomlVersion' option", () => {
-    plugin.application.options.setValue('nomnomlVersion', '0.0.0');
-
-    const input = '</body>';
-    const result = plugin.convertPageContents(input);
-    expect(result).toMatch('</body>');
-    expect(result).toMatch(
-      /<script src=\"https:\/\/cdnjs.cloudflare.com\/ajax\/libs\/nomnoml\/0\.0\.0\/nomnoml.min.js\"><\/script>/,
-    );
-  });
-
-  // tslint:disable-next-line: quotemark
-  it("load nomnoml@0.6.1 when not to set 'nomnomlVersion' option", () => {
-    const input = '</body>';
-    const result = plugin.convertPageContents(input);
-    expect(result).toMatch('</body>');
-    expect(result).toMatch(
-      /<script src=\"https:\/\/cdnjs.cloudflare.com\/ajax\/libs\/nomnoml\/0\.6\.1\/nomnoml.min.js\"><\/script>/,
-    );
+    expect(result).toContain('<script src="https://cdn.jsdelivr.net/npm/dagre/dist/dagre.min.js"></script>');
+    expect(result).toContain('<script src="https://cdn.jsdelivr.net/npm/nomnoml/dist/nomnoml.min.js"></script>');
+    expect(result).toMatchSnapshot();
   });
 
   it('convert PageContents returns same value if body closing tag not exixt', () => {


### PR DESCRIPTION
`@Option` has been deprecated and slated to be removed in typedoc 0.17.

As a response, the option of `nomnomlVersion` was removed.
